### PR TITLE
Add hid::Led along with knob example using it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ cortex-m-rt = "0.6.12"
 cortex-m-rtic = "0.5.3"
 debouncr = "0.1.2"
 log = "0.4.11"
+micromath = "1.0.1"
 panic-halt = "0.2.0"
 stm32h7xx-hal = { version = "0.6.0", features = ["stm32h750v","rt"], git = "https://github.com/mtthw-meyer/stm32h7xx-hal.git", branch = "sai-i2s-v0.2.x-1" }
 rtt-target = { version = "0.2.0", features = ["cortex-m"], optional = true }

--- a/examples/knob.rs
+++ b/examples/knob.rs
@@ -1,0 +1,91 @@
+//! examples/knob.rs
+#![no_main]
+#![no_std]
+
+use stm32h7xx_hal::adc;
+use stm32h7xx_hal::stm32;
+use stm32h7xx_hal::timer::Timer;
+
+use libdaisy_rust::gpio::*;
+use libdaisy_rust::hid;
+use libdaisy_rust::prelude::*;
+use libdaisy_rust::system;
+use stm32h7xx_hal::time::Hertz;
+
+#[rtic::app(
+    device = stm32h7xx_hal::stm32,
+    peripherals = true,
+    monotonic = rtic::cyccnt::CYCCNT,
+)]
+const APP: () = {
+    struct Resources {
+        led1: hid::Led<Daisy28<Output<PushPull>>>,
+        adc1: adc::Adc<stm32::ADC1, adc::Enabled>,
+        control1: hid::AnalogControl<Daisy21<Analog>>,
+        timer2: Timer<stm32::TIM2>,
+    }
+
+    #[init]
+    fn init(ctx: init::Context) -> init::LateResources {
+        let mut system = system::System::init(ctx.core, ctx.device);
+
+        let duty_cycle = 50;
+        let resolution = 20;
+
+        system.timer2.set_freq(Hertz(duty_cycle * resolution));
+
+        let daisy28 = system
+            .gpio
+            .daisy28
+            .take()
+            .expect("Failed to get pin 28!")
+            .into_push_pull_output();
+
+        let led1 = hid::Led::new(daisy28, false, resolution);
+
+        let mut adc1 = system.adc1.enable();
+        adc1.set_resolution(adc::Resolution::SIXTEENBIT);
+        let adc1_max = adc1.max_sample() as f32;
+
+        let daisy21 = system
+            .gpio
+            .daisy21
+            .take()
+            .expect("Failed to get pin 21!")
+            .into_analog();
+
+        let control1 = hid::AnalogControl::new(daisy21, adc1_max);
+
+        init::LateResources {
+            led1,
+            adc1,
+            control1,
+            timer2: system.timer2,
+        }
+    }
+
+    #[idle]
+    fn idle(_cx: idle::Context) -> ! {
+        loop {
+            cortex_m::asm::nop();
+        }
+    }
+
+    #[task( binds = TIM2, resources = [timer2, adc1, control1, led1] )]
+    fn interface_handler(ctx: interface_handler::Context) {
+        ctx.resources.timer2.clear_irq();
+        let adc1 = ctx.resources.adc1;
+        let led1 = ctx.resources.led1;
+        let control1 = ctx.resources.control1;
+
+        match adc1.read(&mut control1.pin) {
+            Ok(data) => {
+                control1.update(data);
+            }
+            Err(_) => {}
+        }
+
+        led1.set_brightness(control1.get_value());
+        led1.update();
+    }
+};


### PR DESCRIPTION
Ported the [Knob example](https://github.com/electro-smith/DaisyExamples/tree/master/seed/Knob) from the official libraries. The `hid::Led` struct is roughly based on [hid_led.cpp](https://github.com/electro-smith/libDaisy/blob/04479d151dc275203a02e64fbfa2ab2bf6c0a91a/src/hid_led.cpp) with some minor differences. Used [this article](https://www.waitingforfriday.com/?p=404) as reference and so I've renamed `samplerate` which they use in `hid_led.cpp` to `resolution`, which I find is more intuitive. I'm also not sure why they divide 120 on this line [hid_led.cpp#L41](https://github.com/electro-smith/libDaisy/blob/04479d151dc275203a02e64fbfa2ab2bf6c0a91a/src/hid_led.cpp#L41), so I didn't replicate it.

Pulling in the `micromath` crate is purely to get the `f32.sqrt()` function.